### PR TITLE
remove all.missing checks from assertList

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,4 @@ Depends:
 Suggests:
     testthat
 ByteCompile: yes
-RoxygenNote: 5.0.1
+RoxygenNote: 6.1.0

--- a/R/rpn.R
+++ b/R/rpn.R
@@ -60,12 +60,12 @@
 #' @export
 rpn = function(rpn.expr, reverse = TRUE, eval = TRUE, clean = TRUE, vars = list(), ops = list()) {
   # sanity checking
-  assertCharacter(rpn.expr, min.len = 1L, any.missing = FALSE, all.missing = FALSE)
+  assertCharacter(rpn.expr, min.len = 1L, any.missing = FALSE)
   assertFlag(reverse)
   assertFlag(eval)
   assertFlag(clean)
-  assertList(vars, any.missing = FALSE, all.missing = FALSE)
-  assertList(ops, types = "list", any.missing = FALSE, all.missing = FALSE)
+  assertList(vars, any.missing = FALSE)
+  assertList(ops, types = "list", any.missing = FALSE)
 
   default.ops = list(
     "+" = list(2, TRUE, "+"),

--- a/man/rpn.Rd
+++ b/man/rpn.Rd
@@ -4,8 +4,8 @@
 \alias{rpn}
 \title{Reverse Polish Notation converter/interpreter.}
 \usage{
-rpn(rpn.expr, reverse = TRUE, eval = TRUE, clean = TRUE, vars = list(),
-  ops = list())
+rpn(rpn.expr, reverse = TRUE, eval = TRUE, clean = TRUE,
+  vars = list(), ops = list())
 }
 \arguments{
 \item{rpn.expr}{[\code{character}]\cr
@@ -72,4 +72,3 @@ res = rpn(rpe, ops = ops, vars = vars)
 Lukasiewicz, Jan (1957). Aristotle's Syllogistic from the Standpoint of Modern
 Formal Logic. Oxford University Press.
 }
-


### PR DESCRIPTION
There was a bug in checkmate: all.missing and any.missing had no effect in `assertList()`. Fixing the bug breaks your package. I glimpsed at your code, and I believe you just don't want those extra argument checks here.